### PR TITLE
DELETE api call returns None (new 204 No Content response, see #1)

### DIFF
--- a/moneybird/tests.py
+++ b/moneybird/tests.py
@@ -127,8 +127,8 @@ class APIConnectionTest(TestCase):
 
         # Delete the contact from the administration
         delete_result = self.api.delete('contacts/%s' % contact_id, administration_id=adm_id)
-
-        self.assertEqual(delete_result['id'], contact_id, "The contact has not been deleted properly.")
+     
+        self.assertEqual(delete_result, None, "The contact has not been deleted properly.")
 
         # Check deletion
         try:


### PR DESCRIPTION
PR #1 added the 204 HTTP response. Appears the DELETE API call returns `204` with `No Content` which made the `test_contacts_roundtrip` Unit test fail on DELETE response assertion. Testing `delete_result` L131 for `None` fixes the test. (hmm see I left a space indent on 130...).

NB: Noticed `204` was missing in v0.1.3 installed via  `pip` from PyPi, maybe time for a `0.1.4`...